### PR TITLE
API Key is defined in parameters.yml

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,12 +18,6 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('dowdow_league_of_legends_api');
-
-        $rootNode
-            ->children()
-            ->scalarNode('key')->end()
-            ->end();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/DependencyInjection/DowdowLeagueOfLegendsAPIExtension.php
+++ b/DependencyInjection/DowdowLeagueOfLegendsAPIExtension.php
@@ -19,16 +19,17 @@ class DowdowLeagueOfLegendsAPIExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
-
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        if(!$container->hasParameter('dowdow_league_of_legends_api')) {
+            throw new \InvalidArgumentException('The "dowdow_league_of_legends_api" option must be set in parameters');
+        }
+        $bundleParameters = $container->getParameter('dowdow_league_of_legends_api');
 
-        if (!isset($config['key'])) {
+        if (!isset($bundleParameters['key'])) {
             throw new \InvalidArgumentException('The "key" option must be set in "dowdow_league_of_legends_api"');
         }
 
-        $container->setParameter('key', $config['key']);
+        $container->setParameter('key', $bundleParameters['key']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ $bundles = array(
 
 ## Configuration
 
-Add your developer API key in the `config.yml` file :
+Add your developer API key in your `parameters.yml` file :
 
 ```yml
-# app/config/config.yml
-dowdow_league_of_legends_api:
-    key: 054684ee6-7848-4101-this5is58my1key35bitch789
+# app/config/parameters.yml
+parameters:
+    dowdow_league_of_legends_api:
+        key: 054684ee6-7848-4101-this5is58my1key35bitch789
 ```
 
 ## Content


### PR DESCRIPTION
Hi,

With these changes, the API key is defined in parameters.yml.

Pros :
+ far less likely to commit this secret key (parameters.yml should never be versionned)
+ parameters.yml.dist integration : providing a key becomes an installation step

Cons :
+ not compatible with previous configurations